### PR TITLE
Ignore null values

### DIFF
--- a/docs/docs/configuration_options.md
+++ b/docs/docs/configuration_options.md
@@ -55,7 +55,7 @@
 | `Color Palette` | The color palette to use for coloring cells |
 | `Invert Palette` | Invert the color palette's order |
 | `Invert Colors` | Invert all colors used in the panel |
-| `Zero Values` | Determines how empty (zero) cells should be treated.  Possible values are: <ul><li>Regular: Using the lowest color in the selected palette</li><li>Empty: No cell is created</li><li>Customer: Use a custom color</li></ul> |
+| `Zero Values` | Determines how empty (zero) cells should be treated.  Possible values are: <ul><li>Regular: Using the lowest color in the selected palette</li><li>Empty: No cell is created.  Values ignored in average.</li><li>Customer: Use a custom color</li></ul> |
 | `Zero Color` | Custom color to use for empty cells |
 | `Outline Color Type` | Determines how cell outlines should be colored.  Possible values are: <ul><li>Same as cell</li><li>Custom</li></ul> |
 | `Outline Color` | Custom color to use for cell outlines |

--- a/docs/site/configuration_options/index.html
+++ b/docs/site/configuration_options/index.html
@@ -284,7 +284,7 @@
 </tr>
 <tr>
 <td><code>Zero Values</code></td>
-<td>Determines how empty (zero) cells should be treated.  Possible values are: <ul><li>Regular: Using the lowest color in the selected palette</li><li>Empty: No cell is created</li><li>Customer: Use a custom color</li></ul></td>
+<td>Determines how empty (zero) cells should be treated.  Possible values are: <ul><li>Regular: Using the lowest color in the selected palette</li><li>Empty: No cell is created.  Values ignored in average.</li><li>Customer: Use a custom color</li></ul></td>
 </tr>
 <tr>
 <td><code>Zero Color</code></td>

--- a/plugin-test-environment/provisioning/dashboards/dashboards/mosaic_test_null_average.json
+++ b/plugin-test-environment/provisioning/dashboards/dashboards/mosaic_test_null_average.json
@@ -21,7 +21,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 5,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -77,7 +76,7 @@
       },
       "targets": [
         {
-          "csvContent": "Time,series,value,group\n1687272258,A,1,C\n1687272318,A,1,C\n1687272378,A,3,C\n1687272438,A,2,C\n1687272498,A,2,C\n1687272258,B,3,C\n1687272318,B,3,C\n1687272378,B,3,C\n1687272438,B,3,C\n1687272498,B,3,C",
+          "csvContent": "Time,series,value,group\n1687272258,A,1,C\n1687272318,A,1,C\n1687272378,A,0,C\n1687272438,A,2,C\n1687272498,A,2,C\n1687272258,B,3,C\n1687272318,B,3,C\n1687272378,B,3,C\n1687272438,B,3,C\n1687272498,B,3,C",
           "datasource": {
             "type": "testdata",
             "uid": "P53465F745837BCFD"
@@ -99,6 +98,70 @@
         "w": 12,
         "x": 12,
         "y": 0
+      },
+      "id": 4,
+      "options": {
+        "amplitudeField": "value",
+        "bevel": false,
+        "binType": "avg",
+        "cellShape": "rect",
+        "compact": false,
+        "dataFormat": "singleFrame",
+        "discreteScale": false,
+        "enableFocus": false,
+        "groupField": "group",
+        "invertColors": false,
+        "invertPalette": false,
+        "isDark": true,
+        "labelPositionType": "horizontal",
+        "labelType": "series",
+        "leftMargin": 50,
+        "maxColumns": 2,
+        "maxRows": 1000,
+        "maxType": "fromData",
+        "minColumns": 2,
+        "numColumns": 2,
+        "outlineColor": "#000000",
+        "outlineColorType": "same",
+        "outlineWidth": 2,
+        "palette": "interpolateRdYlGn",
+        "rowField": "series",
+        "scaleType": "log",
+        "scaleWidth": 50,
+        "seed": 0,
+        "showScale": true,
+        "showXAxis": true,
+        "smooth": false,
+        "sortMode": "asc",
+        "sortType": "lex",
+        "spacing": 0,
+        "zeroColor": "#000000",
+        "zeroType": "empty"
+      },
+      "targets": [
+        {
+          "csvContent": "Time,series,value,group\n1687272258,A,1,C\n1687272318,A,1,C\n1687272378,A,,C\n1687272438,A,2,C\n1687272498,A,2,C\n1687272258,B,3,C\n1687272318,B,3,C\n1687272378,B,3,C\n1687272438,B,3,C\n1687272498,B,3,C",
+          "datasource": {
+            "type": "testdata",
+            "uid": "P53465F745837BCFD"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Averaging Test With Null (Zeros Value: Empty)",
+      "type": "boazreicher-mosaicplot-panel"
+    },
+    {
+      "datasource": {
+        "type": "testdata",
+        "uid": "P53465F745837BCFD"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 9
       },
       "id": 3,
       "options": {
@@ -163,70 +226,6 @@
         "w": 12,
         "x": 12,
         "y": 9
-      },
-      "id": 4,
-      "options": {
-        "amplitudeField": "value",
-        "bevel": false,
-        "binType": "avg",
-        "cellShape": "rect",
-        "compact": false,
-        "dataFormat": "singleFrame",
-        "discreteScale": false,
-        "enableFocus": false,
-        "groupField": "group",
-        "invertColors": false,
-        "invertPalette": false,
-        "isDark": true,
-        "labelPositionType": "horizontal",
-        "labelType": "series",
-        "leftMargin": 50,
-        "maxColumns": 2,
-        "maxRows": 1000,
-        "maxType": "fromData",
-        "minColumns": 2,
-        "numColumns": 2,
-        "outlineColor": "#000000",
-        "outlineColorType": "same",
-        "outlineWidth": 2,
-        "palette": "interpolateRdYlGn",
-        "rowField": "series",
-        "scaleType": "log",
-        "scaleWidth": 50,
-        "seed": 0,
-        "showScale": true,
-        "showXAxis": true,
-        "smooth": false,
-        "sortMode": "asc",
-        "sortType": "lex",
-        "spacing": 0,
-        "zeroColor": "#000000",
-        "zeroType": "empty"
-      },
-      "targets": [
-        {
-          "csvContent": "Time,series,value,group\n1687272258,A,1,C\n1687272318,A,1,C\n1687272378,A,,C\n1687272438,A,2,C\n1687272498,A,2,C\n1687272258,B,3,C\n1687272318,B,3,C\n1687272378,B,3,C\n1687272438,B,3,C\n1687272498,B,3,C",
-          "datasource": {
-            "type": "testdata",
-            "uid": "P53465F745837BCFD"
-          },
-          "refId": "A",
-          "scenarioId": "csv_content"
-        }
-      ],
-      "title": "Averaging Test With Null (Zeros Value: Empty)",
-      "type": "boazreicher-mosaicplot-panel"
-    },
-    {
-      "datasource": {
-        "type": "testdata",
-        "uid": "P53465F745837BCFD"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 18
       },
       "id": 5,
       "options": {
@@ -297,6 +296,6 @@
   "timezone": "",
   "title": "Average Test",
   "uid": "z0f4kbrVk",
-  "version": 8,
+  "version": 1,
   "weekStart": ""
 }

--- a/plugin-test-environment/provisioning/dashboards/dashboards/mosaic_test_null_average.json
+++ b/plugin-test-environment/provisioning/dashboards/dashboards/mosaic_test_null_average.json
@@ -1,0 +1,302 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 5,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "testdata",
+        "uid": "P53465F745837BCFD"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "amplitudeField": "value",
+        "bevel": false,
+        "binType": "avg",
+        "cellShape": "rect",
+        "compact": false,
+        "dataFormat": "singleFrame",
+        "discreteScale": false,
+        "enableFocus": false,
+        "groupField": "group",
+        "invertColors": false,
+        "invertPalette": false,
+        "isDark": true,
+        "labelPositionType": "horizontal",
+        "labelType": "series",
+        "leftMargin": 50,
+        "maxColumns": 2,
+        "maxRows": 1000,
+        "maxType": "fromData",
+        "minColumns": 2,
+        "numColumns": 2,
+        "outlineColor": "#000000",
+        "outlineColorType": "same",
+        "outlineWidth": 2,
+        "palette": "interpolateRdYlGn",
+        "rowField": "series",
+        "scaleType": "log",
+        "scaleWidth": 50,
+        "seed": 0,
+        "showScale": true,
+        "showXAxis": true,
+        "smooth": false,
+        "sortMode": "asc",
+        "sortType": "lex",
+        "spacing": 0,
+        "zeroColor": "#000000",
+        "zeroType": "regular"
+      },
+      "targets": [
+        {
+          "csvContent": "Time,series,value,group\n1687272258,A,1,C\n1687272318,A,1,C\n1687272378,A,3,C\n1687272438,A,2,C\n1687272498,A,2,C\n1687272258,B,3,C\n1687272318,B,3,C\n1687272378,B,3,C\n1687272438,B,3,C\n1687272498,B,3,C",
+          "datasource": {
+            "type": "testdata",
+            "uid": "P53465F745837BCFD"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Averaging Test (No Nulls)",
+      "type": "boazreicher-mosaicplot-panel"
+    },
+    {
+      "datasource": {
+        "type": "testdata",
+        "uid": "P53465F745837BCFD"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "amplitudeField": "value",
+        "bevel": false,
+        "binType": "avg",
+        "cellShape": "rect",
+        "compact": false,
+        "dataFormat": "singleFrame",
+        "discreteScale": false,
+        "enableFocus": false,
+        "groupField": "group",
+        "invertColors": false,
+        "invertPalette": false,
+        "isDark": true,
+        "labelPositionType": "horizontal",
+        "labelType": "series",
+        "leftMargin": 50,
+        "maxColumns": 2,
+        "maxRows": 1000,
+        "maxType": "fromData",
+        "minColumns": 2,
+        "numColumns": 2,
+        "outlineColor": "#000000",
+        "outlineColorType": "same",
+        "outlineWidth": 2,
+        "palette": "interpolateRdYlGn",
+        "rowField": "series",
+        "scaleType": "log",
+        "scaleWidth": 50,
+        "seed": 0,
+        "showScale": true,
+        "showXAxis": true,
+        "smooth": false,
+        "sortMode": "asc",
+        "sortType": "lex",
+        "spacing": 0,
+        "zeroColor": "#000000",
+        "zeroType": "regular"
+      },
+      "targets": [
+        {
+          "csvContent": "Time,series,value,group\n1687272258,A,1,C\n1687272318,A,1,C\n1687272378,A,,C\n1687272438,A,2,C\n1687272498,A,2,C\n1687272258,B,3,C\n1687272318,B,3,C\n1687272378,B,3,C\n1687272438,B,3,C\n1687272498,B,3,C",
+          "datasource": {
+            "type": "testdata",
+            "uid": "P53465F745837BCFD"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Averaging Test With Null (Zeros Value: Regular)",
+      "type": "boazreicher-mosaicplot-panel"
+    },
+    {
+      "datasource": {
+        "type": "testdata",
+        "uid": "P53465F745837BCFD"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "amplitudeField": "value",
+        "bevel": false,
+        "binType": "avg",
+        "cellShape": "rect",
+        "compact": false,
+        "dataFormat": "singleFrame",
+        "discreteScale": false,
+        "enableFocus": false,
+        "groupField": "group",
+        "invertColors": false,
+        "invertPalette": false,
+        "isDark": true,
+        "labelPositionType": "horizontal",
+        "labelType": "series",
+        "leftMargin": 50,
+        "maxColumns": 2,
+        "maxRows": 1000,
+        "maxType": "fromData",
+        "minColumns": 2,
+        "numColumns": 2,
+        "outlineColor": "#000000",
+        "outlineColorType": "same",
+        "outlineWidth": 2,
+        "palette": "interpolateRdYlGn",
+        "rowField": "series",
+        "scaleType": "log",
+        "scaleWidth": 50,
+        "seed": 0,
+        "showScale": true,
+        "showXAxis": true,
+        "smooth": false,
+        "sortMode": "asc",
+        "sortType": "lex",
+        "spacing": 0,
+        "zeroColor": "#000000",
+        "zeroType": "empty"
+      },
+      "targets": [
+        {
+          "csvContent": "Time,series,value,group\n1687272258,A,1,C\n1687272318,A,1,C\n1687272378,A,,C\n1687272438,A,2,C\n1687272498,A,2,C\n1687272258,B,3,C\n1687272318,B,3,C\n1687272378,B,3,C\n1687272438,B,3,C\n1687272498,B,3,C",
+          "datasource": {
+            "type": "testdata",
+            "uid": "P53465F745837BCFD"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Averaging Test With Null (Zeros Value: Empty)",
+      "type": "boazreicher-mosaicplot-panel"
+    },
+    {
+      "datasource": {
+        "type": "testdata",
+        "uid": "P53465F745837BCFD"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 5,
+      "options": {
+        "amplitudeField": "value",
+        "bevel": false,
+        "binType": "avg",
+        "cellShape": "rect",
+        "compact": false,
+        "dataFormat": "singleFrame",
+        "discreteScale": false,
+        "enableFocus": false,
+        "groupField": "group",
+        "invertColors": false,
+        "invertPalette": false,
+        "isDark": true,
+        "labelPositionType": "horizontal",
+        "labelType": "series",
+        "leftMargin": 50,
+        "maxColumns": 2,
+        "maxRows": 1000,
+        "maxType": "fromData",
+        "minColumns": 2,
+        "numColumns": 2,
+        "outlineColor": "#000000",
+        "outlineColorType": "same",
+        "outlineWidth": 2,
+        "palette": "interpolateRdYlGn",
+        "rowField": "series",
+        "scaleType": "log",
+        "scaleWidth": 50,
+        "seed": 0,
+        "showScale": true,
+        "showXAxis": true,
+        "smooth": false,
+        "sortMode": "asc",
+        "sortType": "lex",
+        "spacing": 0,
+        "zeroColor": "#000000",
+        "zeroType": "empty"
+      },
+      "targets": [
+        {
+          "csvContent": "Time,series,value,group\n1687272258,A,1,C\n1687272318,A,1,C\n1687272438,A,2,C\n1687272498,A,2,C\n1687272258,B,3,C\n1687272318,B,3,C\n1687272438,B,3,C\n1687272498,B,3,C",
+          "datasource": {
+            "type": "testdata",
+            "uid": "P53465F745837BCFD"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Averaging Test With Null Removed from Input (Zeros Value: Empty)",
+      "type": "boazreicher-mosaicplot-panel"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 34,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Average Test",
+  "uid": "z0f4kbrVk",
+  "version": 8,
+  "weekStart": ""
+}

--- a/plugin-test-environment/provisioning/dashboards/dashboards/mosaic_test_null_average.json
+++ b/plugin-test-environment/provisioning/dashboards/dashboards/mosaic_test_null_average.json
@@ -279,6 +279,70 @@
       ],
       "title": "Averaging Test With Null Removed from Input (Zeros Value: Empty)",
       "type": "boazreicher-mosaicplot-panel"
+    },
+    {
+      "datasource": {
+        "type": "testdata",
+        "uid": "P53465F745837BCFD"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 6,
+      "options": {
+        "amplitudeField": "value",
+        "bevel": false,
+        "binType": "avg",
+        "cellShape": "rect",
+        "compact": false,
+        "dataFormat": "singleFrame",
+        "discreteScale": false,
+        "enableFocus": false,
+        "groupField": "group",
+        "invertColors": false,
+        "invertPalette": false,
+        "isDark": true,
+        "labelPositionType": "horizontal",
+        "labelType": "series",
+        "leftMargin": 50,
+        "maxColumns": 2,
+        "maxRows": 1000,
+        "maxType": "fromData",
+        "minColumns": 2,
+        "numColumns": 2,
+        "outlineColor": "#000000",
+        "outlineColorType": "same",
+        "outlineWidth": 2,
+        "palette": "interpolateRdYlGn",
+        "rowField": "series",
+        "scaleType": "log",
+        "scaleWidth": 50,
+        "seed": 0,
+        "showScale": true,
+        "showXAxis": true,
+        "smooth": false,
+        "sortMode": "asc",
+        "sortType": "lex",
+        "spacing": 0,
+        "zeroColor": "#000000",
+        "zeroType": "empty"
+      },
+      "targets": [
+        {
+          "csvContent": "Time,series,value,group\n1687272258,A,,C\n1687272318,A,,C\n1687272438,A,,C\n1687272498,A,2,C\n1687272258,B,3,C\n1687272318,B,3,C\n1687272438,B,3,C\n1687272498,B,3,C",
+          "datasource": {
+            "type": "testdata",
+            "uid": "P53465F745837BCFD"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Averaging Test Entire Bucket Null (Zeros Value: Empty)",
+      "type": "boazreicher-mosaicplot-panel"
     }
   ],
   "refresh": "",
@@ -296,6 +360,6 @@
   "timezone": "",
   "title": "Average Test",
   "uid": "z0f4kbrVk",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/src/MosaicPlot.tsx
+++ b/src/MosaicPlot.tsx
@@ -196,7 +196,8 @@ function initPlotElements(
       timeRange,
       panelOptions.dataFormat,
       panelOptions.maxRows,
-      panelOptions.binType
+      panelOptions.binType,
+      panelOptions.zeroType
     );
     errorMessage = null;
   } catch (error) {

--- a/src/data/SeriesUtils.tsx
+++ b/src/data/SeriesUtils.tsx
@@ -308,7 +308,6 @@ function buildSeries(
     } else if (index > binIndex * binSize && index + 1 > (binIndex + 1) * binSize) {
       // The value overlaps the end of the bin
       let relativePart = 1 - (index + 1 - (binIndex + 1) * binSize);
-      console.log("relativePart: " + relativePart);
       sum += relativePart * values[index];
       remainder = (1 - relativePart) * values[index];
 

--- a/src/data/SeriesUtils.tsx
+++ b/src/data/SeriesUtils.tsx
@@ -331,7 +331,6 @@ function buildSeries(
         case 'avg':
           if (zeroType == 'empty'){
             // do not include nulls in average calculation
-            console.log("nullCount: " + nullCount)
             aggregated = sum / (binSize - nullCount);
           }
           else{
@@ -342,6 +341,7 @@ function buildSeries(
 
       series.addValue(timestamps[binIndex], aggregated);
       sum = 0;
+      nullCount = 0;
       binIndex++;
     }
   }

--- a/src/data/SeriesUtils.tsx
+++ b/src/data/SeriesUtils.tsx
@@ -1,5 +1,5 @@
 import { DataFrame, Vector } from '@grafana/data';
-import { BinType, DataFormat, MaxType, SortMode, SortType } from 'types';
+import { BinType, DataFormat, MaxType, SortMode, SortType, ZeroType } from 'types';
 import { Series } from './Series';
 import { TimeRange } from './TimeRange';
 
@@ -14,7 +14,8 @@ export function getDataSeries(
   timeRange: TimeRange,
   dataFormat: DataFormat,
   maxRows: number,
-  binType: BinType
+  binType: BinType,
+  zeroType: ZeroType
 ): Series[] {
   let rows: Record<string, Series> = {};
 
@@ -22,7 +23,7 @@ export function getDataSeries(
     if (dataFrames.length > 1) {
       throw new Error('Single frame data format expects exactly 1 data frame.  Found ' + dataFrames.length);
     }
-    extractRowsFromSingleFrame(rows, dataFrames[0], numColumns, timeRange, valueField, rowField, groupField, binType);
+    extractRowsFromSingleFrame(rows, dataFrames[0], numColumns, timeRange, valueField, rowField, groupField, binType, zeroType);
   } else {
     dataFrames.forEach((dataFrame) => {
       let timestamps = calculateTimestamps(dataFrame.fields, numColumns, timeRange);
@@ -214,7 +215,8 @@ function addRows(
   numColumns: number,
   dataFormat: string,
   binType: BinType,
-  timestamps: number[]
+  timestamps: number[],
+  zeroType: ZeroType
 ) {
   fields.forEach((field) => {
     if (field.type === 'time') {
@@ -255,7 +257,7 @@ function addRows(
       console.warn('Found multiple series with ' + rowField + ': ' + rowName + ', using last...');
     }
 
-    rows[rowName] = buildSeries(rowName, groupName, createValuesArray(field.values), numColumns, binType, timestamps);
+    rows[rowName] = buildSeries(rowName, groupName, createValuesArray(field.values), numColumns, binType, timestamps, zeroType);
   });
 }
 
@@ -275,7 +277,8 @@ function buildSeries(
   values: number[],
   numColumns: number,
   binType: BinType,
-  timestamps: number[]
+  timestamps: number[],
+  zeroType: ZeroType
 ): Series {
   let series = new Series(rowName, groupName);
 
@@ -284,18 +287,36 @@ function buildSeries(
   let sum = 0;
   let remainder = 0;
   let binIndex = 0;
+  let nullCount = 0;
+  let nullRemainder = 0;
+  let isNull = false;
 
   for (let index = 0; index < values.length; index++) {
     sum += remainder;
+    nullCount += nullRemainder;
+
+    isNull = values[index] == null
+
     if (index >= binIndex * binSize && index + 1 <= (binIndex + 1) * binSize) {
       // The value is completely in the bin
       sum += values[index];
       remainder = 0;
+      nullRemainder = 0;
+
+      if(isNull){nullCount += 1}
+
+      nullCount += 1;
     } else if (index > binIndex * binSize && index + 1 > (binIndex + 1) * binSize) {
       // The value overlaps the end of the bin
       let relativePart = 1 - (index + 1 - (binIndex + 1) * binSize);
       sum += relativePart * values[index];
       remainder = (1 - relativePart) * values[index];
+
+      if(isNull){
+        nullCount += relativePart;
+        nullRemainder = 1 - relativePart
+      }
+
     } else {
       throw new Error('This shouldnt happen');
     }
@@ -308,7 +329,13 @@ function buildSeries(
           aggregated = sum;
           break;
         case 'avg':
-          aggregated = sum / binSize;
+          if (zeroType == 'empty'){
+            // do not include nulls in average calculation
+            aggregated = sum / (binSize - nullCount);
+          }
+          else{
+            aggregated = sum / binSize;
+          }
           break;
       }
 
@@ -367,7 +394,8 @@ function extractRowsFromSingleFrame(
   valueField: string,
   rowField: string,
   groupField: string,
-  binType: BinType
+  binType: BinType,
+  zeroType: ZeroType
 ) {
   let fieldRowIndex = 0;
   let timeFieldName = '';
@@ -455,6 +483,6 @@ function extractRowsFromSingleFrame(
     if (groupNames.hasOwnProperty(rowName)) {
       groupName = groupNames[rowName];
     }
-    rows[rowName] = buildSeries(rowName, groupName, values[rowName], numColumns, binType, formattedTimestamps);
+    rows[rowName] = buildSeries(rowName, groupName, values[rowName], numColumns, binType, formattedTimestamps, zeroType);
   }
 }

--- a/src/data/SeriesUtils.tsx
+++ b/src/data/SeriesUtils.tsx
@@ -27,7 +27,7 @@ export function getDataSeries(
   } else {
     dataFrames.forEach((dataFrame) => {
       let timestamps = calculateTimestamps(dataFrame.fields, numColumns, timeRange);
-      addRows(rows, dataFrame.fields, valueField, rowField, groupField, numColumns, dataFormat, binType, timestamps);
+      addRows(rows, dataFrame.fields, valueField, rowField, groupField, numColumns, dataFormat, binType, timestamps, zeroType);
     });
   }
 
@@ -305,10 +305,10 @@ function buildSeries(
 
       if(isNull){nullCount += 1}
 
-      nullCount += 1;
     } else if (index > binIndex * binSize && index + 1 > (binIndex + 1) * binSize) {
       // The value overlaps the end of the bin
       let relativePart = 1 - (index + 1 - (binIndex + 1) * binSize);
+      console.log("relativePart: " + relativePart);
       sum += relativePart * values[index];
       remainder = (1 - relativePart) * values[index];
 
@@ -331,6 +331,7 @@ function buildSeries(
         case 'avg':
           if (zeroType == 'empty'){
             // do not include nulls in average calculation
+            console.log("nullCount: " + nullCount)
             aggregated = sum / (binSize - nullCount);
           }
           else{

--- a/src/data/SeriesUtils.tsx
+++ b/src/data/SeriesUtils.tsx
@@ -295,7 +295,7 @@ function buildSeries(
     sum += remainder;
     nullCount += nullRemainder;
 
-    isNull = values[index] == null
+    isNull = values[index] == null;
 
     if (index >= binIndex * binSize && index + 1 <= (binIndex + 1) * binSize) {
       // The value is completely in the bin
@@ -303,7 +303,7 @@ function buildSeries(
       remainder = 0;
       nullRemainder = 0;
 
-      if(isNull){nullCount += 1}
+      if(isNull){nullCount += 1;}
 
     } else if (index > binIndex * binSize && index + 1 > (binIndex + 1) * binSize) {
       // The value overlaps the end of the bin
@@ -313,7 +313,7 @@ function buildSeries(
 
       if(isNull){
         nullCount += relativePart;
-        nullRemainder = 1 - relativePart
+        nullRemainder = 1 - relativePart;
       }
 
     } else {

--- a/src/data/SeriesUtils.tsx
+++ b/src/data/SeriesUtils.tsx
@@ -357,9 +357,9 @@ function buildSeries(
           aggregated = sum;
           break;
         case 'avg':
-          if (zeroType == 'empty' && nullCount == binSize) {
+          if (zeroType === 'empty' && nullCount === binSize) {
             aggregated = 0;
-          } else if (zeroType == 'empty') {
+          } else if (zeroType === 'empty') {
             // do not include nulls in average calculation
             aggregated = sum / (binSize - nullCount);
           } else {

--- a/src/data/SeriesUtils.tsx
+++ b/src/data/SeriesUtils.tsx
@@ -303,7 +303,9 @@ function buildSeries(
       remainder = 0;
       nullRemainder = 0;
 
-      if(isNull){nullCount += 1;}
+      if (isNull) {
+        nullCount += 1;
+      }
 
     } else if (index > binIndex * binSize && index + 1 > (binIndex + 1) * binSize) {
       // The value overlaps the end of the bin
@@ -311,7 +313,7 @@ function buildSeries(
       sum += relativePart * values[index];
       remainder = (1 - relativePart) * values[index];
 
-      if(isNull){
+      if (isNull) {
         nullCount += relativePart;
         nullRemainder = 1 - relativePart;
       }
@@ -328,11 +330,14 @@ function buildSeries(
           aggregated = sum;
           break;
         case 'avg':
-          if (zeroType == 'empty'){
+          if (zeroType == 'empty' && nullCount == binSize) {
+            aggregated = 0;
+          }
+          else if (zeroType == 'empty') {
             // do not include nulls in average calculation
             aggregated = sum / (binSize - nullCount);
           }
-          else{
+          else {
             aggregated = sum / binSize;
           }
           break;

--- a/src/data/SeriesUtils.tsx
+++ b/src/data/SeriesUtils.tsx
@@ -23,11 +23,32 @@ export function getDataSeries(
     if (dataFrames.length > 1) {
       throw new Error('Single frame data format expects exactly 1 data frame.  Found ' + dataFrames.length);
     }
-    extractRowsFromSingleFrame(rows, dataFrames[0], numColumns, timeRange, valueField, rowField, groupField, binType, zeroType);
+    extractRowsFromSingleFrame(
+      rows,
+      dataFrames[0],
+      numColumns,
+      timeRange,
+      valueField,
+      rowField,
+      groupField,
+      binType,
+      zeroType
+    );
   } else {
     dataFrames.forEach((dataFrame) => {
       let timestamps = calculateTimestamps(dataFrame.fields, numColumns, timeRange);
-      addRows(rows, dataFrame.fields, valueField, rowField, groupField, numColumns, dataFormat, binType, timestamps, zeroType);
+      addRows(
+        rows,
+        dataFrame.fields,
+        valueField,
+        rowField,
+        groupField,
+        numColumns,
+        dataFormat,
+        binType,
+        timestamps,
+        zeroType
+      );
     });
   }
 
@@ -257,7 +278,15 @@ function addRows(
       console.warn('Found multiple series with ' + rowField + ': ' + rowName + ', using last...');
     }
 
-    rows[rowName] = buildSeries(rowName, groupName, createValuesArray(field.values), numColumns, binType, timestamps, zeroType);
+    rows[rowName] = buildSeries(
+      rowName,
+      groupName,
+      createValuesArray(field.values),
+      numColumns,
+      binType,
+      timestamps,
+      zeroType
+    );
   });
 }
 
@@ -306,7 +335,6 @@ function buildSeries(
       if (isNull) {
         nullCount += 1;
       }
-
     } else if (index > binIndex * binSize && index + 1 > (binIndex + 1) * binSize) {
       // The value overlaps the end of the bin
       let relativePart = 1 - (index + 1 - (binIndex + 1) * binSize);
@@ -317,7 +345,6 @@ function buildSeries(
         nullCount += relativePart;
         nullRemainder = 1 - relativePart;
       }
-
     } else {
       throw new Error('This shouldnt happen');
     }
@@ -332,12 +359,10 @@ function buildSeries(
         case 'avg':
           if (zeroType == 'empty' && nullCount == binSize) {
             aggregated = 0;
-          }
-          else if (zeroType == 'empty') {
+          } else if (zeroType == 'empty') {
             // do not include nulls in average calculation
             aggregated = sum / (binSize - nullCount);
-          }
-          else {
+          } else {
             aggregated = sum / binSize;
           }
           break;
@@ -488,6 +513,14 @@ function extractRowsFromSingleFrame(
     if (groupNames.hasOwnProperty(rowName)) {
       groupName = groupNames[rowName];
     }
-    rows[rowName] = buildSeries(rowName, groupName, values[rowName], numColumns, binType, formattedTimestamps, zeroType);
+    rows[rowName] = buildSeries(
+      rowName,
+      groupName,
+      values[rowName],
+      numColumns,
+      binType,
+      formattedTimestamps,
+      zeroType
+    );
   }
 }


### PR DESCRIPTION
Calculates null count (including overlapping buckets) and uses it to ignore nulls in the average when `zeroType == 'empty'`.